### PR TITLE
fixed track.proxy call to look within context

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,16 +38,16 @@ function send(track, fn){
    * @return {string}
    */
   var getName = function() {
-    var name = track.proxy('traits.name');
+    var name = track.proxy('context.traits.name'); //context.traits only exists on mobile
     if (name) return name;
 
-    var firstName = track.proxy('traits.firstName');
-    var lastName = track.proxy('traits.lastName');
+    var firstName = track.proxy('context.traits.firstName'); //context.traits only exists on mobile
+    var lastName = track.proxy('context.traits.lastName'); //context.traits only exists on mobile
     if (firstName && lastName) return firstName + ' ' + lastName;
     if (firstName) return firstName;
     if (lastName) return lastName;
 
-    var username = track.proxy('traits.username');
+    var username = track.proxy('context.traits.username'); //context.traits only exists on mobile
     if (username) return username;
 
     var email = track.email();


### PR DESCRIPTION
track.proxy('traits.name') will be undefined 100% of the time. 

So, I changed it to be track.proxy('context.traits.name'). This change will barely affect anyone (only mobile users who rely on context.traits for their slack integration, but for the sanity of the next person who reads our slack integration code, this will be very helpful.