### PR TITLE
Add Slack Attachments and Unfurl support to integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 coverage
 node_modules
+.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,9 +77,21 @@ function send(track, fn) {
     icon_url: 'https://logo.clearbit.com/segment.com'
   };
 
-  if (templateData.properties && templateData.properties.attachments) {
+  if (templateData.properties && typeof templateData.properties.attachments !== 'undefined') {
     extend(payload, {
       attachments: templateData.properties.attachments
+    });
+  }
+
+  if (templateData.properties && typeof templateData.properties['unfurl-links'] !== 'undefined') {
+    extend(payload, {
+      'unfurl-links': templateData.properties['unfurl-links']
+    });
+  }
+
+  if (templateData.properties && typeof templateData.properties['unfurl-media'] !== 'undefined') {
+    extend(payload, {
+      'unfurl-media': templateData.properties['unfurl-media']
     });
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,6 +77,12 @@ function send(track, fn){
     icon_url: 'https://logo.clearbit.com/segment.com'
   };
 
+  if (templateData.properties && templateData.properties.attachments) {
+    extend(payload, {
+      attachments: templateData.properties.attachments
+    });
+  }
+
   var channel = this.settings.channels[track.event()];
   if (channel) payload.channel = channel;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ var Slack = module.exports = integration('Slack')
 Slack.prototype.track = send;
 
 /** Send an event to the Slack API. */
-function send(track, fn){
+function send(track, fn) {
   /**
    * Get a human readable name for the user:
    * 1. Check traits.name

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,15 +83,15 @@ function send(track, fn) {
     });
   }
 
-  if (templateData.properties && typeof templateData.properties['unfurl-links'] !== 'undefined') {
+  if (templateData.properties && typeof templateData.properties.unfurl_links !== 'undefined') {
     extend(payload, {
-      'unfurl-links': templateData.properties['unfurl-links']
+      unfurl_links: templateData.properties.unfurl_links
     });
   }
 
-  if (templateData.properties && typeof templateData.properties['unfurl-media'] !== 'undefined') {
+  if (templateData.properties && typeof templateData.properties.unfurl_media !== 'undefined') {
     extend(payload, {
-      'unfurl-media': templateData.properties['unfurl-media']
+      unfurl_media: templateData.properties.unfurl_media
     });
   }
 

--- a/test/fixtures/track-attachment.json
+++ b/test/fixtures/track-attachment.json
@@ -1,0 +1,34 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "attachments": [
+        {
+          "fallback": "New ticket from Andrea Lee - Ticket #1943: Can't rest my password - https://groove.hq/path/to/ticket/1943",
+          "pretext": "New ticket from Andrea Lee",
+          "title": "Ticket #1943: Can't reset my password",
+          "title_link": "https://groove.hq/path/to/ticket/1943",
+          "text": "Help! I tried to reset my password but nothing happened!",
+          "color": "#7CD197"
+        }
+      ]
+    }
+  },
+  "output": {
+    "text": "User user-id did my-event.",
+    "attachments": [
+      {
+        "fallback": "New ticket from Andrea Lee - Ticket #1943: Can't rest my password - https://groove.hq/path/to/ticket/1943",
+        "pretext": "New ticket from Andrea Lee",
+        "title": "Ticket #1943: Can't reset my password",
+        "title_link": "https://groove.hq/path/to/ticket/1943",
+        "text": "Help! I tried to reset my password but nothing happened!",
+        "color": "#7CD197"
+      }
+    ]
+  }
+}

--- a/test/fixtures/track-attachments.json
+++ b/test/fixtures/track-attachments.json
@@ -1,0 +1,68 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "attachments": [
+        {
+          "fallback": "New ticket from Andrea Lee - Ticket #1943: Can't rest my password - https://groove.hq/path/to/ticket/1943",
+          "pretext": "New ticket from Andrea Lee",
+          "title": "Ticket #1943: Can't reset my password",
+          "title_link": "https://groove.hq/path/to/ticket/1943",
+          "text": "Help! I tried to reset my password but nothing happened!",
+          "color": "#7CD197"
+        },
+        {
+          "fallback": "ReferenceError - UI is not defined: https://honeybadger.io/path/to/event/",
+          "text": "<https://honeybadger.io/path/to/event/|ReferenceError> - UI is not defined",
+          "fields": [
+            {
+              "title": "Project",
+              "value": "Awesome Project",
+              "short": true
+            },
+            {
+              "title": "Environment",
+              "value": "production",
+              "short": true
+            }
+          ],
+          "color": "#F35A00"
+        }
+      ]
+    }
+  },
+  "output": {
+    "text": "User user-id did my-event.",
+    "attachments": [
+      {
+        "fallback": "New ticket from Andrea Lee - Ticket #1943: Can't rest my password - https://groove.hq/path/to/ticket/1943",
+        "pretext": "New ticket from Andrea Lee",
+        "title": "Ticket #1943: Can't reset my password",
+        "title_link": "https://groove.hq/path/to/ticket/1943",
+        "text": "Help! I tried to reset my password but nothing happened!",
+        "color": "#7CD197"
+      },
+      {
+        "fallback": "ReferenceError - UI is not defined: https://honeybadger.io/path/to/event/",
+        "text": "<https://honeybadger.io/path/to/event/|ReferenceError> - UI is not defined",
+        "fields": [
+          {
+            "title": "Project",
+            "value": "Awesome Project",
+            "short": true
+          },
+          {
+            "title": "Environment",
+            "value": "production",
+            "short": true
+          }
+        ],
+        "color": "#F35A00"
+      }
+    ]
+  }
+}

--- a/test/fixtures/track-unfurl-and-attachments.json
+++ b/test/fixtures/track-unfurl-and-attachments.json
@@ -6,7 +6,7 @@
     "timestamp": "2014",
     "properties": {
       "revenue": 19.99,
-      "unfurl-links": true,
+      "unfurl_links": true,
       "attachments": [
         {
           "fallback": "New ticket from Andrea Lee - Ticket #1943: Can't rest my password - https://groove.hq/path/to/ticket/1943",
@@ -21,7 +21,7 @@
   },
   "output": {
     "text": "User user-id did my-event.",
-    "unfurl-links": true,
+    "unfurl_links": true,
     "attachments": [
       {
         "fallback": "New ticket from Andrea Lee - Ticket #1943: Can't rest my password - https://groove.hq/path/to/ticket/1943",

--- a/test/fixtures/track-unfurl-and-attachments.json
+++ b/test/fixtures/track-unfurl-and-attachments.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "unfurl-links": true,
+      "attachments": [
+        {
+          "fallback": "New ticket from Andrea Lee - Ticket #1943: Can't rest my password - https://groove.hq/path/to/ticket/1943",
+          "pretext": "New ticket from Andrea Lee",
+          "title": "Ticket #1943: Can't reset my password",
+          "title_link": "https://groove.hq/path/to/ticket/1943",
+          "text": "Help! I tried to reset my password but nothing happened!",
+          "color": "#7CD197"
+        }
+      ]
+    }
+  },
+  "output": {
+    "text": "User user-id did my-event.",
+    "unfurl-links": true,
+    "attachments": [
+      {
+        "fallback": "New ticket from Andrea Lee - Ticket #1943: Can't rest my password - https://groove.hq/path/to/ticket/1943",
+        "pretext": "New ticket from Andrea Lee",
+        "title": "Ticket #1943: Can't reset my password",
+        "title_link": "https://groove.hq/path/to/ticket/1943",
+        "text": "Help! I tried to reset my password but nothing happened!",
+        "color": "#7CD197"
+      }
+    ]
+  }
+}

--- a/test/fixtures/track-unfurl-false.json
+++ b/test/fixtures/track-unfurl-false.json
@@ -1,0 +1,18 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "unfurl-links": false,
+      "unfurl-media": false
+    }
+  },
+  "output": {
+    "text": "User user-id did my-event.",
+    "unfurl-links": false,
+    "unfurl-media": false
+  }
+}

--- a/test/fixtures/track-unfurl-false.json
+++ b/test/fixtures/track-unfurl-false.json
@@ -6,13 +6,13 @@
     "timestamp": "2014",
     "properties": {
       "revenue": 19.99,
-      "unfurl-links": false,
-      "unfurl-media": false
+      "unfurl_links": false,
+      "unfurl_media": false
     }
   },
   "output": {
     "text": "User user-id did my-event.",
-    "unfurl-links": false,
-    "unfurl-media": false
+    "unfurl_links": false,
+    "unfurl_media": false
   }
 }

--- a/test/fixtures/track-unfurl-links-only.json
+++ b/test/fixtures/track-unfurl-links-only.json
@@ -6,11 +6,11 @@
     "timestamp": "2014",
     "properties": {
       "revenue": 19.99,
-      "unfurl-links": true
+      "unfurl_links": true
     }
   },
   "output": {
     "text": "User user-id did my-event.",
-    "unfurl-links": true
+    "unfurl_links": true
   }
 }

--- a/test/fixtures/track-unfurl-links-only.json
+++ b/test/fixtures/track-unfurl-links-only.json
@@ -1,0 +1,16 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "unfurl-links": true
+    }
+  },
+  "output": {
+    "text": "User user-id did my-event.",
+    "unfurl-links": true
+  }
+}

--- a/test/fixtures/track-unfurl-media-only.json
+++ b/test/fixtures/track-unfurl-media-only.json
@@ -1,0 +1,16 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "unfurl-media": true
+    }
+  },
+  "output": {
+    "text": "User user-id did my-event.",
+    "unfurl-media": true
+  }
+}

--- a/test/fixtures/track-unfurl-media-only.json
+++ b/test/fixtures/track-unfurl-media-only.json
@@ -6,11 +6,11 @@
     "timestamp": "2014",
     "properties": {
       "revenue": 19.99,
-      "unfurl-media": true
+      "unfurl_media": true
     }
   },
   "output": {
     "text": "User user-id did my-event.",
-    "unfurl-media": true
+    "unfurl_media": true
   }
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -21,11 +21,11 @@ var email = 'testing-' + firstId + '@segment.io';
  * @return {Function}
  */
 
-exports.mapper = function(dirname){
+exports.mapper = function(dirname) {
   assert(dirname, '__dirname must be supplied');
   dirname = join(dirname, 'fixtures');
-  return function(integration){
-    integration.fixture = function(name, settings){
+  return function(integration) {
+    integration.fixture = function(name, settings) {
       var dir = join(dirname, name + '.json');
       var json = require(dir);
       var input = json.input;
@@ -47,7 +47,7 @@ exports.mapper = function(dirname){
  * @return {Track}
  */
 
-exports.transaction = function(options){
+exports.transaction = function(options) {
   return new facade.Track(merge({
     userId: firstId,
     channel: 'server',
@@ -86,7 +86,7 @@ exports.transaction = function(options){
  * @return {Track}
  */
 
-exports.track = function (options) {
+exports.track = function(options) {
   options = options || {};
   return new facade.Track(merge({
     userId     : firstId,
@@ -133,7 +133,7 @@ exports.track = function (options) {
  */
 
 
-exports.track.bare = function (options) {
+exports.track.bare = function(options) {
   return new facade.Track(merge({
     userId  : 'aaa',
     event   : 'Bear tracks',
@@ -148,7 +148,7 @@ exports.track.bare = function (options) {
  * @return {Identify}
  */
 
-exports.identify = function (options) {
+exports.identify = function(options) {
   options = options || {};
   return new facade.Identify(merge({
     userId : firstId,
@@ -188,7 +188,7 @@ exports.identify = function (options) {
  * @return {Page}
  */
 
-exports.page = function(options){
+exports.page = function(options) {
   return new facade.Page(merge({
     userId: firstId,
     name: 'Docs',
@@ -212,7 +212,7 @@ exports.page = function(options){
  * @return {Page}
  */
 
-exports.screen = function(options){
+exports.screen = function(options) {
   return new facade.Screen(merge({
     userId: firstId,
     name: 'Login',
@@ -235,7 +235,7 @@ exports.screen = function(options){
  * @return {Group}
  */
 
-exports.group = function(options){
+exports.group = function(options) {
   return new facade.Group(merge({
     groupId: groupId,
     userId: firstId,
@@ -245,7 +245,7 @@ exports.group = function(options){
       state: 'CA',
       city: 'San Francisco',
       created: new Date('2/1/2014'),
-      plan: 'Enterprise',
+      plan: 'Enterprise'
     },
     context: {
       ip: '12.212.12.49'
@@ -262,7 +262,7 @@ exports.group = function(options){
  * @return {Alias}
  */
 
-exports.alias = function (options) {
+exports.alias = function(options) {
   return new facade.Alias(merge({
     from      : firstId,
     to        : secondId,

--- a/test/index.js
+++ b/test/index.js
@@ -170,7 +170,55 @@ describe('Slack', function() {
     });
 
     it('should pass through multiple attachments to the Slack API call', function(done) {
-      var json = test.fixture('track-attachment');
+      var json = test.fixture('track-attachments');
+      var output = json.output;
+      output.username = 'Segment';
+      output.icon_url = 'https://logo.clearbit.com/segment.com';
+      test
+          .set(settings)
+          .track(json.input)
+          .sends(output)
+          .expects(200, done);
+    });
+
+    it('should pass both "unfurls" as false if explicitly present', function(done) {
+      var json = test.fixture('track-unfurl-false');
+      var output = json.output;
+      output.username = 'Segment';
+      output.icon_url = 'https://logo.clearbit.com/segment.com';
+      test
+          .set(settings)
+          .track(json.input)
+          .sends(output)
+          .expects(200, done);
+    });
+
+    it('should pass "unfurl-links" as true if explicitly present', function(done) {
+      var json = test.fixture('track-unfurl-links-only');
+      var output = json.output;
+      output.username = 'Segment';
+      output.icon_url = 'https://logo.clearbit.com/segment.com';
+      test
+          .set(settings)
+          .track(json.input)
+          .sends(output)
+          .expects(200, done);
+    });
+
+    it('should pass "unfurl-media" as true if explicitly present', function(done) {
+      var json = test.fixture('track-unfurl-media-only');
+      var output = json.output;
+      output.username = 'Segment';
+      output.icon_url = 'https://logo.clearbit.com/segment.com';
+      test
+          .set(settings)
+          .track(json.input)
+          .sends(output)
+          .expects(200, done);
+    });
+
+    it('should pass "unfurl" and "attachments" fields', function(done) {
+      var json = test.fixture('track-unfurl-and-attachments');
       var output = json.output;
       output.username = 'Segment';
       output.icon_url = 'https://logo.clearbit.com/segment.com';

--- a/test/index.js
+++ b/test/index.js
@@ -156,5 +156,29 @@ describe('Slack', function() {
         .sends(output)
         .expects(200, done);
     });
+
+    it('should pass through an attachment to the Slack API call', function(done){
+      var json = test.fixture('track-attachment');
+      var output = json.output;
+      output.username = 'Segment';
+      output.icon_url = 'https://logo.clearbit.com/segment.com';
+      test
+          .set(settings)
+          .track(json.input)
+          .sends(output)
+          .expects(200, done);
+    });
+
+    it('should pass through multiple attachments to the Slack API call', function(done){
+      var json = test.fixture('track-attachment');
+      var output = json.output;
+      output.username = 'Segment';
+      output.icon_url = 'https://logo.clearbit.com/segment.com';
+      test
+          .set(settings)
+          .track(json.input)
+          .sends(output)
+          .expects(200, done);
+    });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ describe('Slack', function() {
   var settings;
   var test;
 
-  beforeEach(function(){
+  beforeEach(function() {
     settings = {
       webhookUrl: 'https://hooks.slack.com/services/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',
       channels: {},
@@ -19,7 +19,7 @@ describe('Slack', function() {
     test = Test(slack, __dirname);
   });
 
-  it('should have the correct settings', function(){
+  it('should have the correct settings', function() {
     test
       .name('Slack')
       .channels(['server', 'mobile', 'client'])
@@ -27,17 +27,17 @@ describe('Slack', function() {
   });
 
   describe('.validate()', function() {
-    it('should not be valid without a webhookUrl', function(){
+    it('should not be valid without a webhookUrl', function() {
       test.invalid({}, {});
     });
 
-    it('should be valid with a webhookUrl', function(){
+    it('should be valid with a webhookUrl', function() {
       test.valid({}, { webhookUrl: 'webhookUrl' });
     });
   });
 
   describe('.track()', function() {
-    it('should map track calls correctly', function(done){
+    it('should map track calls correctly', function(done) {
       var json = test.fixture('track-basic');
       var output = json.output;
       output.username = 'Segment';
@@ -49,13 +49,13 @@ describe('Slack', function() {
         .expects(200, done);
     });
 
-    it('should fail invalid templates gracefully', function(done){
+    it('should fail invalid templates gracefully', function(done) {
       var json = test.fixture('track-basic');
       var output = json.output;
       output.username = 'Segment';
       output.icon_url = 'https://logo.clearbit.com/segment.com';
       settings.templates = {
-        "my-event": "{{invalid template"
+        'my-event': '{{invalid template'
       };
       test
         .set(settings)
@@ -63,7 +63,7 @@ describe('Slack', function() {
         .error(done);
     });
 
-    it('should map track calls with email correctly', function(done){
+    it('should map track calls with email correctly', function(done) {
       var json = test.fixture('track-email');
       var output = json.output;
       output.username = 'Segment';
@@ -75,7 +75,7 @@ describe('Slack', function() {
         .expects(200, done);
     });
 
-    it('should map track calls with name correctly', function(done){
+    it('should map track calls with name correctly', function(done) {
       var json = test.fixture('track-name');
       var output = json.output;
       output.username = 'Segment';
@@ -87,7 +87,7 @@ describe('Slack', function() {
         .expects(200, done);
     });
 
-    it('should map track calls with first and last name correctly', function(done){
+    it('should map track calls with first and last name correctly', function(done) {
       var json = test.fixture('track-name-first-last');
       var output = json.output;
       output.username = 'Segment';
@@ -99,7 +99,7 @@ describe('Slack', function() {
         .expects(200, done);
     });
 
-    it('should map track calls with username correctly', function(done){
+    it('should map track calls with username correctly', function(done) {
       var json = test.fixture('track-username');
       var output = json.output;
       output.username = 'Segment';
@@ -111,14 +111,14 @@ describe('Slack', function() {
         .expects(200, done);
     });
 
-    it('should map track calls with custom channel correctly', function(done){
+    it('should map track calls with custom channel correctly', function(done) {
       var json = test.fixture('track-basic');
       var output = json.output;
-      output.channel = '#testing-slack-api'
+      output.channel = '#testing-slack-api';
       output.username = 'Segment';
       output.icon_url = 'https://logo.clearbit.com/segment.com';
       settings.channels = {
-        "my-event": "#testing-slack-api"
+        'my-event': '#testing-slack-api'
       };
       test
         .set(settings)
@@ -127,13 +127,13 @@ describe('Slack', function() {
         .expects(200, done);
     });
 
-    it('should map track calls with custom templates correctly', function(done){
+    it('should map track calls with custom templates correctly', function(done) {
       var json = test.fixture('track-template');
       var output = json.output;
       output.username = 'Segment';
       output.icon_url = 'https://logo.clearbit.com/segment.com';
       settings.templates = {
-        "Completed Order": "{{name}} bought an item worth ${{properties.revenue}}"
+        'Completed Order': '{{name}} bought an item worth ${{properties.revenue}}'
       };
       test
         .set(settings)
@@ -142,7 +142,7 @@ describe('Slack', function() {
         .expects(200, done);
     });
 
-    it('should decode HTML entities from templates', function(done){
+    it('should decode HTML entities from templates', function(done) {
       var json = test.fixture('track-entities');
       var output = json.output;
       settings.templates = {
@@ -157,7 +157,7 @@ describe('Slack', function() {
         .expects(200, done);
     });
 
-    it('should pass through an attachment to the Slack API call', function(done){
+    it('should pass through an attachment to the Slack API call', function(done) {
       var json = test.fixture('track-attachment');
       var output = json.output;
       output.username = 'Segment';
@@ -169,7 +169,7 @@ describe('Slack', function() {
           .expects(200, done);
     });
 
-    it('should pass through multiple attachments to the Slack API call', function(done){
+    it('should pass through multiple attachments to the Slack API call', function(done) {
       var json = test.fixture('track-attachment');
       var output = json.output;
       output.username = 'Segment';


### PR DESCRIPTION
I added passthrough features for the "attachments", "unfurl-links", and "unfurl-media" properties in a track call's context data to be added directly to the Slack API call. This allows users to send attachments or unfurled links / images directly through Segment. I checked that all existing tests still completed, added a few tests to ensure future support and cleaned up some lint formatting errors.

To review:
- I didn't know if there were any specific naming schemes, so these properties passthrough with their names. Let me know if you would like some prefix (like "slack-") added to them to prevent overlap with user-defined properties.
- I haven't actually tested the integration through Segment to see if it works. Let me know how I could do this and I would gladly do so.